### PR TITLE
feature: new plugin option to allow http Host header passthrough

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -3,6 +3,8 @@
 ReProxied is a middleware plugin for [Traefik](https://github.com/traefik/traefik) to route an incoming request through a proxy.
 Be aware that this middleware initiates the call to the proxy and any middlewares after this one will be skipped. If the request to the proxy itself fails the middleware will respond with a 502 bad gateway response.
 
+When set to `true` the parameter `keepHostHeader` allow to keep original Host as HTTP header even if proxied request target any other host.
+
 ## Configuration
 
 ### Static
@@ -16,6 +18,7 @@ experimental:
     reproxied:
       moduleName: "github.com/nilskohrs/reproxied"
       version: "v0.0.3"
+      keepHostHeader: true|false # optional, false by default
 ```
 
 ### Dynamic
@@ -27,4 +30,5 @@ http:
       reproxied:
         proxy: http://proxyHost:3128
         targetHost: https://example.com
+        keepHostHeader: true|false # optional, false by default
 ```

--- a/reproxied_test.go
+++ b/reproxied_test.go
@@ -46,3 +46,36 @@ func TestShouldChangeHost(t *testing.T) {
 		t.Errorf("expected request host to be updated to \"target.com\" but was actually: %v", clientMock.executedRequest[0].Host)
 	}
 }
+
+func TestShouldKeepHostHeader(t *testing.T) {
+	clientMock := &ClientMock{}
+
+	cfg := reproxied.CreateConfig()
+	cfg.Proxy = "http://proxy:3128"
+	cfg.TargetHost = "https://target.com"
+	cfg.KeepHostHeader = true
+
+	ctx := context.Background()
+	next := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {})
+
+	handler, err := reproxied.NewWithClient(ctx, next, cfg, "reProxied", clientMock)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	recorder := httptest.NewRecorder()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://internal.url/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	handler.ServeHTTP(recorder, req)
+
+	if clientMock.executedRequest[0].URL.Host != "target.com" {
+		t.Errorf("expected request host to be updated to \"target.com\" but was actually: %v", clientMock.executedRequest[0].URL.Host)
+	}
+	if clientMock.executedRequest[0].Host != "internal.url" {
+		t.Errorf("expected request header host to be kept to \"internal.url\" but was actually: %v", clientMock.executedRequest[0].Host)
+	}
+}


### PR DESCRIPTION
Hello, thanks your development on this plugin it is usefull to me. If you think this is an acceptable feature I propose you to introduce a new configuration flag to allow original HTTP Host header conservation.
